### PR TITLE
Ignore the ./localStorage JSON files in PM2 watch

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Now install the package you'll be using to run the job in the background:
 
 ```bash
     sudo npm install pm2 -g
-    sudo pm2 start ./runner.js -i 1 --name "last-updated-hack" --trace --watch ./
+    sudo pm2 start pm2.ecosystem.json --only last-updated-hack
 ```
 
 You can see what's running with:

--- a/pm2.ecosystem.json
+++ b/pm2.ecosystem.json
@@ -3,7 +3,7 @@
     "name": "last-updated-hack",
     "script": "./runner.js",
     "watch": ["./"],
-    "ignore_watch": ["./localStorage/"],
+    "ignore_watch": ["./localStorage/*.json"],
     "instances": 1,
     "trace": true    
   }]

--- a/pm2.ecosystem.json
+++ b/pm2.ecosystem.json
@@ -1,0 +1,10 @@
+{
+  "apps": [{
+    "name": "last-updated-hack",
+    "script": "./runner.js",
+    "watch": ["./"],
+    "ignore_watch": ["./localStorage/"],
+    "instances": 1,
+    "trace": true    
+  }]
+}


### PR DESCRIPTION
Initially, the hack wasn't completing its runs. The PM2 logs said:

```
PM2 | [2018-06-01 15:00:03] PM2 error: Change detected on path localStorage/table1.json for app last-updated-hack - restarting
PM2 | [2018-06-01 15:00:03] PM2 log: Stopping app:last-updated-hack id:0
PM2 | [2018-06-01 15:00:03] PM2 log: App name:last-updated-hack id:0 disconnected
```

which, uh, makes sense, because we had set `--watch ./`. The pm2 declaration was revised. A ecosystem file is used, because (the pm2 docs)[http://pm2.keymetrics.io/docs/usage/watch-and-restart/] say "to watch specific paths, please use a JS/JSON app declaration".